### PR TITLE
fixed pci_read_config_word error when compiling on ubuntu 16.04

### DIFF
--- a/common/rtmp_mcu.c
+++ b/common/rtmp_mcu.c
@@ -618,7 +618,7 @@ INT RtmpAsicSendCommandToMcu(
 			&& (pAd->HostVendor != PCIBUS_INTEL_VENDOR)))
 		{
 			offset = 0x70F;
-			pci_read_config_word(((POS_COOKIE)pAd->OS_Cookie)->pci_dev, offset, &Configuration); 
+			pci_read_config_word(((POS_COOKIE)pAd->OS_Cookie)->pci_dev, offset, (u16*)&Configuration); 
 			Configuration=le2cpu16(Configuration);
 			Configuration &= 0xffffff00;
 			Configuration |= (0x13);	/* set Latency to default */
@@ -638,7 +638,7 @@ INT RtmpAsicSendCommandToMcu(
 		{
 			offset = 0x70F;
 			/* Configuration = RTMPReadCBConfigXP(pAd, offset); */
-			pci_read_config_word(((POS_COOKIE)pAd->OS_Cookie)->pci_dev, offset, &Configuration);
+			pci_read_config_word(((POS_COOKIE)pAd->OS_Cookie)->pci_dev, offset, (u16*)&Configuration);
 			Configuration=le2cpu16(Configuration);
 
 			Configuration &= 0xffffff00;


### PR DESCRIPTION
this fixed the compilation error for ubuntu 16.04, which gives the error as mentioned in the title. valid pointer casts where not given in rtmp_mcu.c