### PR TITLE
patch for Linux kernel 4.15.0-39

### DIFF
--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -527,8 +527,12 @@ typedef struct tasklet_struct  *POS_NET_TASK_STRUCT;
 typedef struct timer_list	OS_NDIS_MINIPORT_TIMER;
 typedef struct timer_list	OS_TIMER;
 
-typedef void (*TIMER_FUNCTION)(unsigned long);
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0))
+typedef void (*TIMER_FUNCTION)(unsigned long);
+#else
+typedef void (*TIMER_FUNCTION)(struct timer_list *);
+#endif
 
 #define OS_WAIT(_time) \
 {	\

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -114,9 +114,13 @@ static inline VOID __RTMP_OS_Init_Timer(
 	IN PVOID data)
 {
 	if (!timer_pending(pTimer)) {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0))
 		init_timer(pTimer);
 		pTimer->data = (unsigned long)data;
 		pTimer->function = function;
+#else
+        timer_setup(pTimer, function, 0);
+#endif
 	}
 }
 

--- a/os/linux/sta_ioctl.c
+++ b/os/linux/sta_ioctl.c
@@ -691,7 +691,7 @@ int rt_ioctl_iwaplist(struct net_device *dev,
 		set_quality(pAd, &qual[i], pList); /*&pAd->ScanTab.BssEntry[i]); */
 	}
 	data->length = i;
-	memcpy(extra, &addr, i*sizeof(addr[0]));
+	memcpy(extra, addr, i*sizeof(struct sockaddr));
 	data->flags = 1;		/* signal quality present (sort of) */
 	memcpy(extra + i*sizeof(addr[0]), &qual, i*sizeof(qual[i]));
 


### PR DESCRIPTION
I think this should help update this driver for kernel 4.15 and should address this issue: https://github.com/agerwick/RT28XX-RT539X-Linux-driver/issues/10

I could get this to compile (ubuntu 18.04 and gcc 7.3.0) but I can't confirm that the driver functions as expected. I was trying out this for my Asus PCE-N13 (rt2790 chipset) but it might not be a covered device.